### PR TITLE
 Limetorrent: fix url

### DIFF
--- a/limetorrents.cc/addon.json
+++ b/limetorrents.cc/addon.json
@@ -8,7 +8,7 @@
         "limetorrents.cc"
     ],
     "domain": "limetorrents.cc",
-    "version": 100,
+    "version": 101,
     "interface": [
         "ISearch"
     ],

--- a/limetorrents.cc/limetorrents.cc.php
+++ b/limetorrents.cc/limetorrents.cc.php
@@ -1,6 +1,6 @@
 <?php
 class limetorrents implements ISite, ISearch {
-    const SITE = "https://www-limetorrents-cc.pbproxy.lol"; // use a proxy because limetorrents.cc go into localhost in my QNAP.
+    const SITE = "https://www.limetorrents.lol"; // use a proxy because limetorrents.cc go into localhost in my QNAP.
     private $url;
     
     /*


### PR DESCRIPTION
URL is not usable anymore. Here is a new one.
